### PR TITLE
Introduce `Process::new(...)` as the only public way of spawning a pr…

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,21 +3,6 @@
 version = 4
 
 [[package]]
-name = "addr2line"
-version = "0.25.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b5d307320b3181d6d7954e663bd7c774a838b8220fe0593c86d9fb09f498b4b"
-dependencies = [
- "gimli",
-]
-
-[[package]]
-name = "adler2"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
-
-[[package]]
 name = "aho-corasick"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -72,21 +57,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
-name = "backtrace"
-version = "0.3.76"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb531853791a215d7c62a30daf0dde835f381ab5de4589cfe7c649d2cbe92bd6"
-dependencies = [
- "addr2line",
- "cfg-if",
- "libc",
- "miniz_oxide",
- "object",
- "rustc-demangle",
- "windows-link",
-]
-
-[[package]]
 name = "bitflags"
 version = "2.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -100,9 +70,9 @@ checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
 name = "cfg-if"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fd1289c04a9ea8cb22300a459a72a385d7c73d3259e2ed7dcb2af674838cfa9"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "cfg_aliases"
@@ -229,38 +199,21 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
  "libc",
  "r-efi",
- "wasi 0.14.7+wasi-0.2.4",
+ "wasip2",
 ]
-
-[[package]]
-name = "gimli"
-version = "0.32.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
 
 [[package]]
 name = "indoc"
 version = "2.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4c7245a08504955605670dbf141fceab975f15ca21570696aebe9d2e71576bd"
-
-[[package]]
-name = "io-uring"
-version = "0.7.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "046fa2d4d00aea763528b4950358d0ead425372445dc8ff86312b3c69ff7727b"
-dependencies = [
- "bitflags",
- "cfg-if",
- "libc",
-]
 
 [[package]]
 name = "jiff"
@@ -343,22 +296,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 
 [[package]]
-name = "miniz_oxide"
-version = "0.8.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
-dependencies = [
- "adler2",
-]
-
-[[package]]
 name = "mio"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78bed444cc8a2160f01cbcf811ef18cac863ad68ae8ca62092e8db51d51c761c"
 dependencies = [
  "libc",
- "wasi 0.11.1+wasi-snapshot-preview1",
+ "wasi",
  "windows-sys 0.59.0",
 ]
 
@@ -483,15 +427,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "object"
-version = "0.37.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -590,12 +525,6 @@ name = "regex-syntax"
 version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
-
-[[package]]
-name = "rustc-demangle"
-version = "0.1.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56f7d92ca342cea22a06f2121d944b4fd82af56988c270852495420f961d4ace"
 
 [[package]]
 name = "rustix"
@@ -730,27 +659,24 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.47.1"
+version = "1.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89e49afdadebb872d3145a5638b59eb0691ea23e46ca484037cfab3b76b95038"
+checksum = "ff360e02eab121e0bc37a2d3b4d4dc622e6eda3a8e5253d5435ecf5bd4c68408"
 dependencies = [
- "backtrace",
  "bytes",
- "io-uring",
  "libc",
  "mio",
  "pin-project-lite",
  "signal-hook-registry",
- "slab",
  "tokio-macros",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "2.5.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
+checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -886,15 +812,6 @@ name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
-
-[[package]]
-name = "wasi"
-version = "0.14.7+wasi-0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "883478de20367e224c0090af9cf5f9fa85bed63a95c1abf3afc5c083ebc06e8c"
-dependencies = [
- "wasip2",
-]
 
 [[package]]
 name = "wasip2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ authors = ["Lukas Potthast <privat@lukas-potthast.de>"]
 [dependencies]
 bytes = { version = "1.10.1", default-features = false, features = ["std"] }
 thiserror = { version = "2.0.17", default-features = false, features = ["std"] }
-tokio = { version = "1.47.1", default-features = false, features = ["process", "sync", "io-util", "macros", "rt-multi-thread", "time"] }
+tokio = { version = "1.48.0", default-features = false, features = ["process", "sync", "io-util", "macros", "rt-multi-thread", "time"] }
 tracing = { version = "0.1.41", default-features = false, features = ["std"] }
 
 [target.'cfg(unix)'.dependencies]
@@ -30,6 +30,6 @@ assertr = "0.4.0"
 jiff = "0.2.15"
 mockall = "0.13.1"
 tempfile = "3.23.0"
-tokio = { version = "1.47.1", features = ["fs"] }
+tokio = { version = "1.48.0", features = ["fs"] }
 tokio-test = "0.4.4"
 tracing-test = "0.2.5"

--- a/src/process.rs
+++ b/src/process.rs
@@ -1,0 +1,780 @@
+//! Builder API for spawning processes with explicit stream type selection.
+
+use crate::output_stream::broadcast::BroadcastOutputStream;
+use crate::output_stream::single_subscriber::SingleSubscriberOutputStream;
+use crate::output_stream::{DEFAULT_CHANNEL_CAPACITY, DEFAULT_CHUNK_SIZE};
+use crate::{NumBytes, ProcessHandle};
+use std::borrow::Cow;
+use std::io;
+
+/// Controls how the process name is automatically generated when not explicitly provided.
+///
+/// This determines what information is included in the auto-generated process name
+/// used for logging and debugging purposes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AutoName {
+    /// Capture a name from the command as specified by the provided settings.
+    ///
+    /// Example: `"ls -la"` from `Command::new("ls").arg("-la")`
+    Using(AutoNameSettings),
+
+    /// Capture the full Debug representation of the Command.
+    ///
+    /// Example: `"Command { std: \"ls\" \"-la\", kill_on_drop: false }"`
+    ///
+    /// Note: This includes internal implementation details and may change with tokio updates.
+    Debug,
+}
+
+impl Default for AutoName {
+    fn default() -> Self {
+        Self::Using(AutoNameSettings::program_with_args())
+    }
+}
+
+/// Controls in detail which parts of the command are automatically captured as the process name.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct AutoNameSettings {
+    include_current_dir: bool,
+    include_envs: bool,
+    include_program: bool,
+    include_args: bool,
+}
+
+impl AutoNameSettings {
+    /// Capture the program name.
+    ///
+    /// Example: `Command::new("ls").arg("-la").env("FOO", "foo)` is captured as `"ls"`.
+    pub fn program_only() -> Self {
+        AutoNameSettings {
+            include_current_dir: false,
+            include_envs: false,
+            include_program: true,
+            include_args: false,
+        }
+    }
+
+    /// Capture the program name and all arguments.
+    ///
+    /// Example: `Command::new("ls").arg("-la").env("FOO", "foo)` is captured as `"ls -la"`.
+    pub fn program_with_args() -> Self {
+        AutoNameSettings {
+            include_current_dir: false,
+            include_envs: false,
+            include_program: true,
+            include_args: true,
+        }
+    }
+
+    /// Capture the program name and all environment variables and arguments.
+    ///
+    /// Example: `Command::new("ls").arg("-la").env("FOO", "foo)` is captured as `"FOO=foo ls -la"`.
+    pub fn program_with_env_and_args() -> Self {
+        AutoNameSettings {
+            include_current_dir: false,
+            include_envs: true,
+            include_program: true,
+            include_args: true,
+        }
+    }
+
+    /// Capture the directory and the program name and all environment variables and arguments.
+    ///
+    /// Example: `Command::new("ls").arg("-la").env("FOO", "foo)` is captured as `"/some/dir % FOO=foo ls -la"`.
+    pub fn full() -> Self {
+        AutoNameSettings {
+            include_current_dir: true,
+            include_envs: true,
+            include_program: true,
+            include_args: true,
+        }
+    }
+
+    fn format_cmd(&self, cmd: &std::process::Command) -> String {
+        let mut name = String::new();
+        if self.include_current_dir {
+            if let Some(current_dir) = cmd.get_current_dir() {
+                name.push_str(current_dir.to_string_lossy().as_ref());
+                name.push_str(" % ");
+            }
+        }
+        if self.include_envs {
+            let envs = cmd.get_envs();
+            if envs.len() != 0 {
+                for (key, value) in envs
+                    .filter(|(_key, value)| value.is_some())
+                    .map(|(key, value)| (key, value.expect("present")))
+                {
+                    name.push_str(key.to_string_lossy().as_ref());
+                    name.push('=');
+                    name.push_str(value.to_string_lossy().as_ref());
+                    name.push(' ');
+                }
+            }
+        }
+        if self.include_program {
+            name.push_str(cmd.get_program().to_string_lossy().as_ref());
+            name.push(' ');
+        }
+        if self.include_args {
+            let args = cmd.get_args();
+            if args.len() != 0 {
+                for arg in args {
+                    name.push('"');
+                    name.push_str(arg.to_string_lossy().as_ref());
+                    name.push('"');
+                    name.push(' ');
+                }
+            }
+        }
+        if name.ends_with(' ') {
+            name.pop();
+        }
+        name
+    }
+}
+
+/// Specifies how a process should be named.
+///
+/// This enum allows you to either provide an explicit name or configure automatic
+/// name generation. Using this type ensures you cannot accidentally set both an
+/// explicit name and an auto-naming mode at the same time.
+#[derive(Debug, Clone)]
+pub enum ProcessName {
+    /// Use an explicit custom name.
+    ///
+    /// Example: `ProcessName::Explicit("my-server")`
+    Explicit(Cow<'static, str>),
+
+    /// Auto-generate the name based on the command.
+    ///
+    /// Example: `ProcessName::Auto(AutoName::ProgramWithArgs)`
+    Auto(AutoName),
+}
+
+impl Default for ProcessName {
+    fn default() -> Self {
+        Self::Auto(AutoName::default())
+    }
+}
+
+impl From<&'static str> for ProcessName {
+    fn from(s: &'static str) -> Self {
+        Self::Explicit(Cow::Borrowed(s))
+    }
+}
+
+impl From<String> for ProcessName {
+    fn from(s: String) -> Self {
+        Self::Explicit(Cow::Owned(s))
+    }
+}
+
+impl From<Cow<'static, str>> for ProcessName {
+    fn from(s: Cow<'static, str>) -> Self {
+        Self::Explicit(s)
+    }
+}
+
+impl From<AutoName> for ProcessName {
+    fn from(mode: AutoName) -> Self {
+        Self::Auto(mode)
+    }
+}
+
+/// A builder for configuring and spawning a process.
+///
+/// This provides an ergonomic API for spawning processes while keeping the stream type
+/// (broadcast vs single subscriber) explicit at the spawn callsite.
+///
+/// # Examples
+///
+/// ```no_run
+/// use tokio_process_tools::Process;
+/// use tokio::process::Command;
+///
+/// # tokio_test::block_on(async {
+/// // Simple case with auto-derived name
+/// let process = Process::new(Command::new("ls"))
+///     .spawn_broadcast()?;
+///
+/// // With explicit name (no allocation when using string literal)
+/// let process = Process::new(Command::new("server"))
+///     .name("my-server")
+///     .spawn_single_subscriber()?;
+///
+/// // With custom capacities
+/// let process = Process::new(Command::new("cargo"))
+///     .name("test-runner")
+///     .stdout_capacity(512)
+///     .stderr_capacity(512)
+///     .spawn_broadcast()?;
+/// # Ok::<_, std::io::Error>(())
+/// # });
+/// ```
+pub struct Process {
+    cmd: tokio::process::Command,
+    name: ProcessName,
+    stdout_chunk_size: NumBytes,
+    stderr_chunk_size: NumBytes,
+    stdout_capacity: usize,
+    stderr_capacity: usize,
+}
+
+impl Process {
+    /// Creates a new process builder from a tokio command.
+    ///
+    /// If no name is explicitly set via [`Process::name`], the name will be auto-derived
+    /// from the command's program name.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use tokio_process_tools::Process;
+    /// use tokio::process::Command;
+    ///
+    /// # tokio_test::block_on(async {
+    /// let process = Process::new(Command::new("ls"))
+    ///     .spawn_broadcast()?;
+    /// # Ok::<_, std::io::Error>(())
+    /// # });
+    /// ```
+    pub fn new(cmd: tokio::process::Command) -> Self {
+        Self {
+            cmd,
+            name: ProcessName::default(),
+            stdout_chunk_size: DEFAULT_CHUNK_SIZE,
+            stderr_chunk_size: DEFAULT_CHUNK_SIZE,
+            stdout_capacity: DEFAULT_CHANNEL_CAPACITY,
+            stderr_capacity: DEFAULT_CHANNEL_CAPACITY,
+        }
+    }
+
+    /// Sets how the process should be named.
+    ///
+    /// You can provide either an explicit name or configure automatic name generation.
+    /// The name is used for logging and debugging purposes.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use tokio_process_tools::{Process, ProcessName, AutoName, AutoNameSettings};
+    /// use tokio::process::Command;
+    ///
+    /// # tokio_test::block_on(async {
+    /// // Explicit name
+    /// let process = Process::new(Command::new("server"))
+    ///     .name(ProcessName::Explicit("my-server".into()))
+    ///     .spawn_broadcast()?;
+    ///
+    /// // Auto-generated with arguments
+    /// let mut cmd = Command::new("cargo");
+    /// cmd.arg("test");
+    /// let process = Process::new(cmd)
+    ///     .name(ProcessName::Auto(AutoName::Using(AutoNameSettings::program_with_args())))
+    ///     .spawn_broadcast()?;
+    /// # Ok::<_, std::io::Error>(())
+    /// # });
+    /// ```
+    pub fn name(mut self, name: impl Into<ProcessName>) -> Self {
+        self.name = name.into();
+        self
+    }
+
+    /// Convenience method to set an explicit process name.
+    ///
+    /// This is a shorthand for `.name(ProcessName::Explicit(...))`.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use tokio_process_tools::Process;
+    /// use tokio::process::Command;
+    ///
+    /// # tokio_test::block_on(async {
+    /// // Static name (no allocation)
+    /// let process = Process::new(Command::new("server"))
+    ///     .with_name("my-server")
+    ///     .spawn_broadcast()?;
+    ///
+    /// // Dynamic name (allocates)
+    /// let id = 42;
+    /// let process = Process::new(Command::new("worker"))
+    ///     .with_name(format!("worker-{id}"))
+    ///     .spawn_single_subscriber()?;
+    /// # Ok::<_, std::io::Error>(())
+    /// # });
+    /// ```
+    pub fn with_name(self, name: impl Into<Cow<'static, str>>) -> Self {
+        self.name(ProcessName::Explicit(name.into()))
+    }
+
+    /// Convenience method to configure automatic name generation.
+    ///
+    /// This is a shorthand for `.name(ProcessName::Auto(...))`.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use tokio_process_tools::{AutoName, AutoNameSettings, Process};
+    /// use tokio::process::Command;
+    ///
+    /// # tokio_test::block_on(async {
+    /// let mut cmd = Command::new("server");
+    /// cmd.arg("--database").arg("sqlite");
+    /// cmd.env("S3_ENDPOINT", "127.0.0.1:9000");
+    ///
+    /// let process = Process::new(cmd)
+    ///     .with_auto_name(AutoName::Using(AutoNameSettings::program_with_env_and_args()))
+    ///     .spawn_broadcast()?;
+    /// # Ok::<_, std::io::Error>(())
+    /// # });
+    /// ```
+    pub fn with_auto_name(self, mode: AutoName) -> Self {
+        self.name(ProcessName::Auto(mode))
+    }
+
+    /// Sets the stdout chunk size.
+    ///
+    /// This controls the size of the buffer used when reading from the process's stdout stream.
+    /// Default is [DEFAULT_CHUNK_SIZE].
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use tokio_process_tools::{NumBytesExt, Process};
+    /// use tokio::process::Command;
+    ///
+    /// # tokio_test::block_on(async {
+    /// let process = Process::new(Command::new("server"))
+    ///     .stdout_chunk_size(32.kilobytes())
+    ///     .spawn_broadcast()?;
+    /// # Ok::<_, std::io::Error>(())
+    /// # });
+    /// ```
+    pub fn stdout_chunk_size(mut self, chunk_size: NumBytes) -> Self {
+        self.stdout_chunk_size = chunk_size;
+        self
+    }
+
+    /// Sets the stderr chunk size.
+    ///
+    /// This controls the size of the buffer used when reading from the process's stderr stream.
+    /// Default is [DEFAULT_CHUNK_SIZE].
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use tokio_process_tools::{Process, NumBytesExt};
+    /// use tokio::process::Command;
+    ///
+    /// # tokio_test::block_on(async {
+    /// let process = Process::new(Command::new("server"))
+    ///     .stderr_chunk_size(32.kilobytes())
+    ///     .spawn_broadcast()?;
+    /// # Ok::<_, std::io::Error>(())
+    /// # });
+    /// ```
+    pub fn stderr_chunk_size(mut self, chunk_size: NumBytes) -> Self {
+        self.stderr_chunk_size = chunk_size;
+        self
+    }
+
+    /// Sets the stdout and stderr chunk sizes.
+    ///
+    /// This controls the size of the buffers used when reading from the process's stdout and
+    /// stderr streams.
+    /// Default is [DEFAULT_CHUNK_SIZE].
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use tokio_process_tools::{Process, NumBytesExt};
+    /// use tokio::process::Command;
+    ///
+    /// # tokio_test::block_on(async {
+    /// let process = Process::new(Command::new("server"))
+    ///     .chunk_sizes(32.kilobytes())
+    ///     .spawn_broadcast()?;
+    /// # Ok::<_, std::io::Error>(())
+    /// # });
+    /// ```
+    pub fn chunk_sizes(mut self, chunk_size: NumBytes) -> Self {
+        self.stdout_chunk_size = chunk_size;
+        self.stderr_chunk_size = chunk_size;
+        self
+    }
+
+    /// Sets the stdout channel capacity.
+    ///
+    /// This controls how many chunks can be buffered before backpressure is applied.
+    /// Default is [DEFAULT_CHANNEL_CAPACITY].
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use tokio_process_tools::Process;
+    /// use tokio::process::Command;
+    ///
+    /// # tokio_test::block_on(async {
+    /// let process = Process::new(Command::new("server"))
+    ///     .stdout_capacity(512)
+    ///     .spawn_broadcast()?;
+    /// # Ok::<_, std::io::Error>(())
+    /// # });
+    /// ```
+    pub fn stdout_capacity(mut self, capacity: usize) -> Self {
+        self.stdout_capacity = capacity;
+        self
+    }
+
+    /// Sets the stderr channel capacity.
+    ///
+    /// This controls how many chunks can be buffered before backpressure is applied.
+    /// Default is [DEFAULT_CHANNEL_CAPACITY].
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use tokio_process_tools::Process;
+    /// use tokio::process::Command;
+    ///
+    /// # tokio_test::block_on(async {
+    /// let process = Process::new(Command::new("server"))
+    ///     .stderr_capacity(256)
+    ///     .spawn_broadcast()?;
+    /// # Ok::<_, std::io::Error>(())
+    /// # });
+    /// ```
+    pub fn stderr_capacity(mut self, capacity: usize) -> Self {
+        self.stderr_capacity = capacity;
+        self
+    }
+
+    /// Sets the stdout and stderr channel capacity.
+    ///
+    /// This controls how many chunks can be buffered before backpressure is applied.
+    /// Default is [DEFAULT_CHANNEL_CAPACITY].
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use tokio_process_tools::Process;
+    /// use tokio::process::Command;
+    ///
+    /// # tokio_test::block_on(async {
+    /// let process = Process::new(Command::new("server"))
+    ///     .capacities(256)
+    ///     .spawn_broadcast()?;
+    /// # Ok::<_, std::io::Error>(())
+    /// # });
+    /// ```
+    pub fn capacities(mut self, capacity: usize) -> Self {
+        self.stdout_capacity = capacity;
+        self.stderr_capacity = capacity;
+        self
+    }
+
+    /// Generates a process name based on the configured naming strategy.
+    fn generate_name(&self) -> Cow<'static, str> {
+        match &self.name {
+            ProcessName::Explicit(name) => name.clone(),
+            ProcessName::Auto(auto_name) => match auto_name {
+                AutoName::Using(settings) => settings.format_cmd(self.cmd.as_std()).into(),
+                AutoName::Debug => format!("{:?}", self.cmd).into(),
+            },
+        }
+    }
+
+    /// Spawns the process with broadcast output streams.
+    ///
+    /// Broadcast streams support multiple concurrent consumers of stdout/stderr,
+    /// which is useful when you need to inspect, collect, and process output
+    /// simultaneously. This comes with slightly higher memory overhead due to cloning.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use tokio_process_tools::Process;
+    /// use tokio::process::Command;
+    ///
+    /// # tokio_test::block_on(async {
+    /// let mut process = Process::new(Command::new("ls"))
+    ///     .spawn_broadcast()?;
+    ///
+    /// // Multiple consumers can read the same output
+    /// let _logger = process.stdout().inspect_lines(|line| {
+    ///     println!("{}", line);
+    ///     tokio_process_tools::Next::Continue
+    /// }, Default::default());
+    ///
+    /// let _collector = process.stdout().collect_lines_into_vec(Default::default());
+    /// # Ok::<_, std::io::Error>(())
+    /// # });
+    /// ```
+    pub fn spawn_broadcast(self) -> io::Result<ProcessHandle<BroadcastOutputStream>> {
+        let name = self.generate_name();
+        ProcessHandle::<BroadcastOutputStream>::spawn_with_capacity(
+            name,
+            self.cmd,
+            self.stdout_chunk_size,
+            self.stderr_chunk_size,
+            self.stdout_capacity,
+            self.stderr_capacity,
+        )
+    }
+
+    /// Spawns the process with single subscriber output streams.
+    ///
+    /// Single subscriber streams are more efficient (lower memory, no cloning) but
+    /// only allow one consumer of stdout/stderr at a time. Use this when you only
+    /// need to either inspect OR collect output, not both simultaneously.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use tokio_process_tools::Process;
+    /// use tokio::process::Command;
+    ///
+    /// # tokio_test::block_on(async {
+    /// let mut process = Process::new(Command::new("ls"))
+    ///     .spawn_single_subscriber()?;
+    ///
+    /// // Only one consumer allowed
+    /// let collector = process.stdout_mut().collect_lines_into_vec(Default::default());
+    /// # Ok::<_, std::io::Error>(())
+    /// # });
+    /// ```
+    pub fn spawn_single_subscriber(
+        self,
+    ) -> io::Result<ProcessHandle<SingleSubscriberOutputStream>> {
+        let name = self.generate_name();
+        ProcessHandle::<SingleSubscriberOutputStream>::spawn_with_capacity(
+            name,
+            self.cmd,
+            self.stdout_chunk_size,
+            self.stderr_chunk_size,
+            self.stdout_capacity,
+            self.stderr_capacity,
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{LineParsingOptions, NumBytesExt, Output, OutputStream};
+    use assertr::prelude::*;
+    use std::path::PathBuf;
+    use tokio::process::Command;
+
+    #[tokio::test]
+    async fn process_builder_broadcast() {
+        let mut process = Process::new(Command::new("ls"))
+            .spawn_broadcast()
+            .expect("Failed to spawn");
+
+        assert_that(process.stdout().chunk_size()).is_equal_to(DEFAULT_CHUNK_SIZE);
+        assert_that(process.stderr().chunk_size()).is_equal_to(DEFAULT_CHUNK_SIZE);
+        assert_that(process.stdout().channel_capacity()).is_equal_to(DEFAULT_CHANNEL_CAPACITY);
+        assert_that(process.stderr().channel_capacity()).is_equal_to(DEFAULT_CHANNEL_CAPACITY);
+
+        let Output {
+            status,
+            stdout,
+            stderr,
+        } = process
+            .wait_for_completion_with_output(None, LineParsingOptions::default())
+            .await
+            .unwrap();
+
+        assert_that(status.success()).is_true();
+        assert_that(stdout).is_not_empty();
+        assert_that(stderr).is_empty();
+    }
+
+    #[tokio::test]
+    async fn process_builder_broadcast_with_custom_capacities() {
+        let mut process = Process::new(Command::new("ls"))
+            .stdout_chunk_size(42.kilobytes())
+            .stderr_chunk_size(43.kilobytes())
+            .stdout_capacity(42)
+            .stderr_capacity(43)
+            .spawn_broadcast()
+            .expect("Failed to spawn");
+
+        assert_that(process.stdout().chunk_size()).is_equal_to(42.kilobytes());
+        assert_that(process.stderr().chunk_size()).is_equal_to(43.kilobytes());
+        assert_that(process.stdout().channel_capacity()).is_equal_to(42);
+        assert_that(process.stderr().channel_capacity()).is_equal_to(43);
+
+        let Output {
+            status,
+            stdout,
+            stderr,
+        } = process
+            .wait_for_completion_with_output(None, LineParsingOptions::default())
+            .await
+            .unwrap();
+
+        assert_that(status.success()).is_true();
+        assert_that(stdout).is_not_empty();
+        assert_that(stderr).is_empty();
+    }
+
+    #[tokio::test]
+    async fn process_builder_single_subscriber() {
+        let mut process = Process::new(Command::new("ls"))
+            .spawn_single_subscriber()
+            .expect("Failed to spawn");
+
+        assert_that(process.stdout().chunk_size()).is_equal_to(DEFAULT_CHUNK_SIZE);
+        assert_that(process.stderr().chunk_size()).is_equal_to(DEFAULT_CHUNK_SIZE);
+        assert_that(process.stdout().channel_capacity()).is_equal_to(DEFAULT_CHANNEL_CAPACITY);
+        assert_that(process.stderr().channel_capacity()).is_equal_to(DEFAULT_CHANNEL_CAPACITY);
+
+        let Output {
+            status,
+            stdout,
+            stderr,
+        } = process
+            .wait_for_completion_with_output(None, LineParsingOptions::default())
+            .await
+            .unwrap();
+
+        assert_that(status.success()).is_true();
+        assert_that(stdout).is_not_empty();
+        assert_that(stderr).is_empty();
+    }
+
+    #[tokio::test]
+    async fn process_builder_single_subscriber_with_custom_capacities() {
+        let mut process = Process::new(Command::new("ls"))
+            .stdout_chunk_size(42.kilobytes())
+            .stderr_chunk_size(43.kilobytes())
+            .stdout_capacity(42)
+            .stderr_capacity(43)
+            .spawn_single_subscriber()
+            .expect("Failed to spawn");
+
+        assert_that(process.stdout().chunk_size()).is_equal_to(42.kilobytes());
+        assert_that(process.stderr().chunk_size()).is_equal_to(43.kilobytes());
+        assert_that(process.stdout().channel_capacity()).is_equal_to(42);
+        assert_that(process.stderr().channel_capacity()).is_equal_to(43);
+
+        let Output {
+            status,
+            stdout,
+            stderr,
+        } = process
+            .wait_for_completion_with_output(None, LineParsingOptions::default())
+            .await
+            .unwrap();
+
+        assert_that(status.success()).is_true();
+        assert_that(stdout).is_not_empty();
+        assert_that(stderr).is_empty();
+    }
+
+    #[tokio::test]
+    async fn process_builder_auto_name_captures_command_with_args_if_not_otherwise_specified() {
+        let mut cmd = Command::new("ls");
+        cmd.arg("-la");
+        cmd.env("FOO", "foo");
+        cmd.current_dir(PathBuf::from("./"));
+
+        let mut process = Process::new(cmd)
+            .spawn_broadcast()
+            .expect("Failed to spawn");
+
+        assert_that(&process.name).is_equal_to("ls \"-la\"");
+
+        let _ = process.wait_for_completion(None).await;
+    }
+
+    #[tokio::test]
+    async fn process_builder_auto_name_only_captures_command_when_requested() {
+        let mut cmd = Command::new("ls");
+        cmd.arg("-la");
+        cmd.env("FOO", "foo");
+        cmd.current_dir(PathBuf::from("./"));
+
+        let mut process = Process::new(cmd)
+            .with_auto_name(AutoName::Using(AutoNameSettings::program_only()))
+            .spawn_broadcast()
+            .expect("Failed to spawn");
+
+        assert_that(&process.name).is_equal_to("ls");
+
+        let _ = process.wait_for_completion(None).await;
+    }
+
+    #[tokio::test]
+    async fn process_builder_auto_name_captures_command_with_envs_and_args_when_requested() {
+        let mut cmd = Command::new("ls");
+        cmd.arg("-la");
+        cmd.env("FOO", "foo");
+        cmd.current_dir(PathBuf::from("./"));
+
+        let mut process = Process::new(cmd)
+            .with_auto_name(AutoName::Using(
+                AutoNameSettings::program_with_env_and_args(),
+            ))
+            .spawn_broadcast()
+            .expect("Failed to spawn");
+
+        assert_that(&process.name).is_equal_to("FOO=foo ls \"-la\"");
+
+        let _ = process.wait_for_completion(None).await;
+    }
+
+    #[tokio::test]
+    async fn process_builder_auto_name_captures_command_with_current_dir_envs_and_args_when_requested()
+     {
+        let mut cmd = Command::new("ls");
+        cmd.arg("-la");
+        cmd.env("FOO", "foo");
+        cmd.current_dir(PathBuf::from("./"));
+
+        let mut process = Process::new(cmd)
+            .with_auto_name(AutoName::Using(AutoNameSettings::full()))
+            .spawn_broadcast()
+            .expect("Failed to spawn");
+
+        assert_that(&process.name).is_equal_to("./ % FOO=foo ls \"-la\"");
+
+        let _ = process.wait_for_completion(None).await;
+    }
+
+    #[tokio::test]
+    async fn process_builder_auto_name_captures_full_command_debug_string_when_requested() {
+        let mut cmd = Command::new("ls");
+        cmd.arg("-la");
+        cmd.env("FOO", "foo");
+        cmd.current_dir(PathBuf::from("./"));
+
+        let mut process = Process::new(cmd)
+            .with_auto_name(AutoName::Debug)
+            .spawn_broadcast()
+            .expect("Failed to spawn");
+
+        assert_that(&process.name).is_equal_to(
+            "Command { std: cd \"./\" && FOO=\"foo\" \"ls\" \"-la\", kill_on_drop: false }",
+        );
+
+        let _ = process.wait_for_completion(None).await;
+    }
+
+    #[tokio::test]
+    async fn process_builder_custom_name() {
+        let id = 42;
+        let mut process = Process::new(Command::new("ls"))
+            .with_name(format!("worker-{id}"))
+            .spawn_broadcast()
+            .expect("Failed to spawn");
+
+        assert_that(&process.name).is_equal_to("worker-42");
+
+        let _ = process.wait_for_completion(None).await;
+    }
+}


### PR DESCRIPTION
Introduce `Process::new(...)` as the only public way of spawning a process, allowing users to choose between broadcast and single_subscriber; Add chunk_size and channel_capacity options; Automatically deduce the process name if no explicit name is set