### PR TITLE
Centralize error types

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,101 @@
+//! Error types for process operations.
+
+use std::borrow::Cow;
+use std::io;
+use std::time::Duration;
+use thiserror::Error;
+
+use crate::{CollectorError, InspectorError};
+
+/// Errors that can occur when terminating a process.
+#[derive(Debug, Error)]
+pub enum TerminationError {
+    /// Failed to send a signal to the process.
+    #[error("Failed to send '{signal}' signal to process '{process_name}': {source}")]
+    SignallingFailed {
+        /// The name of the process.
+        process_name: Cow<'static, str>,
+        /// The underlying IO error.
+        source: io::Error,
+        /// The signal that could not be sent.
+        signal: &'static str,
+    },
+
+    /// Failed to terminate the process after trying all signals (SIGINT, SIGTERM, SIGKILL).
+    #[error(
+        "Failed to terminate process '{process_name}'. SIGINT failed: {sigint_error}. SIGTERM failed: {sigterm_error}. SIGKILL failed: {sigkill_error}"
+    )]
+    TerminationFailed {
+        /// The name of the process.
+        process_name: Cow<'static, str>,
+        /// Error from SIGINT attempt.
+        sigint_error: String,
+        /// Error from SIGTERM attempt.
+        sigterm_error: String,
+        /// Error from SIGKILL attempt.
+        #[source]
+        sigkill_error: io::Error,
+    },
+}
+
+/// Errors that can occur when waiting for process operations.
+#[derive(Debug, Error)]
+pub enum WaitError {
+    /// A general IO error occurred.
+    #[error("IO error occurred while waiting for process '{process_name}': {source}")]
+    IoError {
+        /// The name of the process.
+        process_name: Cow<'static, str>,
+        /// The underlying IO error.
+        #[source]
+        source: io::Error,
+    },
+
+    /// Wait operation timed out.
+    #[error("Process '{process_name}' did not complete within {timeout:?}")]
+    Timeout {
+        /// The name of the process.
+        process_name: Cow<'static, str>,
+        /// The timeout duration that was exceeded.
+        timeout: Duration,
+    },
+
+    /// Could not terminate the process.
+    #[error("Could not terminate process: {0}")]
+    TerminationError(#[from] TerminationError),
+
+    /// Collector failed to collect output.
+    #[error("Collector failed to collect output: {0}")]
+    CollectorFailed(#[from] CollectorError),
+}
+
+/// Errors that can occur when spawning a process.
+#[derive(Debug, Error)]
+pub enum SpawnError {
+    /// Failed to spawn the process.
+    #[error("Failed to spawn process '{process_name}': {source}")]
+    SpawnFailed {
+        /// The name or description of the process being spawned.
+        process_name: Cow<'static, str>,
+        /// The underlying IO error.
+        #[source]
+        source: io::Error,
+    },
+}
+
+/// Errors that can occur when waiting for output patterns.
+#[derive(Debug, Error)]
+pub enum OutputError {
+    /// Waiting for output pattern timed out.
+    #[error("Timed out after {timeout:?} waiting for output pattern on {stream_name}")]
+    Timeout {
+        /// The name of the stream.
+        stream_name: &'static str,
+        /// The timeout duration that was exceeded.
+        timeout: Duration,
+    },
+
+    /// Inspector task failed.
+    #[error("Inspector failed: {0}")]
+    InspectorFailed(#[from] InspectorError),
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@
 
 mod async_drop;
 mod collector;
+mod error;
 mod inspector;
 mod output;
 mod output_stream;
@@ -17,6 +18,7 @@ mod terminate_on_drop;
 
 /* public exports */
 pub use collector::{Collector, CollectorError, Sink};
+pub use error::{OutputError, SpawnError, TerminationError, WaitError};
 pub use inspector::{Inspector, InspectorError};
 pub use output::Output;
 pub use output_stream::{
@@ -24,7 +26,7 @@ pub use output_stream::{
     NumBytes, NumBytesExt, OutputStream, broadcast, single_subscriber,
 };
 pub use process::{AutoName, AutoNameSettings, Process, ProcessName};
-pub use process_handle::{ProcessHandle, RunningState, TerminationError, WaitError};
+pub use process_handle::{ProcessHandle, RunningState};
 pub use terminate_on_drop::TerminateOnDrop;
 
 #[cfg(test)]

--- a/src/output_stream/impls.rs
+++ b/src/output_stream/impls.rs
@@ -1,7 +1,8 @@
 macro_rules! impl_inspect_chunks {
-    ($receiver:expr, $f:ident, $handler:ident) => {{
+    ($stream_name:expr, $receiver:expr, $f:ident, $handler:ident) => {{
         let (term_sig_tx, mut term_sig_rx) = tokio::sync::oneshot::channel::<()>();
         Inspector {
+            stream_name: $stream_name,
             task: Some(tokio::spawn(async move {
                 $handler!('outer, $receiver, term_sig_rx, |maybe_chunk| {
                     match maybe_chunk {
@@ -24,9 +25,10 @@ macro_rules! impl_inspect_chunks {
 pub(crate) use impl_inspect_chunks;
 
 macro_rules! impl_inspect_lines {
-    ($receiver:expr, $f:ident, $options:ident, $handler:ident) => {{
+    ($stream_name:expr, $receiver:expr, $f:ident, $options:ident, $handler:ident) => {{
         let (term_sig_tx, mut term_sig_rx) = tokio::sync::oneshot::channel::<()>();
         Inspector {
+            stream_name: $stream_name,
             task: Some(tokio::spawn(async move {
                 let mut line_buffer = bytes::BytesMut::new();
                 $handler!('outer, $receiver, term_sig_rx, |maybe_chunk| {
@@ -57,9 +59,10 @@ macro_rules! impl_inspect_lines {
 pub(crate) use impl_inspect_lines;
 
 macro_rules! impl_inspect_lines_async {
-    ($receiver:expr, $f:ident, $options:ident, $handler:ident) => {{
+    ($stream_name:expr, $receiver:expr, $f:ident, $options:ident, $handler:ident) => {{
         let (term_sig_tx, mut term_sig_rx) = tokio::sync::oneshot::channel::<()>();
         Inspector {
+            stream_name: $stream_name,
             task: Some(tokio::spawn(async move {
                 let mut line_buffer = bytes::BytesMut::new();
                 $handler!('outer, $receiver, term_sig_rx, |maybe_chunk| {
@@ -90,9 +93,10 @@ macro_rules! impl_inspect_lines_async {
 pub(crate) use impl_inspect_lines_async;
 
 macro_rules! impl_collect_chunks {
-    ($receiver:expr, $collect:ident, $sink:ident, $handler:ident) => {{
+    ($stream_name:expr, $receiver:expr, $collect:ident, $sink:ident, $handler:ident) => {{
         let (term_sig_tx, mut term_sig_rx) = tokio::sync::oneshot::channel::<()>();
         Collector {
+            stream_name: $stream_name,
             task: Some(tokio::spawn(async move {
                 $handler!('outer, $receiver, term_sig_rx, |maybe_chunk| {
                     match maybe_chunk {
@@ -115,9 +119,10 @@ macro_rules! impl_collect_chunks {
 pub(crate) use impl_collect_chunks;
 
 macro_rules! impl_collect_lines {
-    ($receiver:expr, $collect:ident, $options:ident, $sink:ident, $handler:ident) => {{
+    ($stream_name:expr, $receiver:expr, $collect:ident, $options:ident, $sink:ident, $handler:ident) => {{
         let (term_sig_tx, mut term_sig_rx) = tokio::sync::oneshot::channel::<()>();
         Collector {
+            stream_name: $stream_name,
             task: Some(tokio::spawn(async move {
                 let mut line_buffer = bytes::BytesMut::new();
                 $handler!('outer, $receiver, term_sig_rx, |maybe_chunk| {
@@ -149,9 +154,10 @@ macro_rules! impl_collect_lines {
 pub(crate) use impl_collect_lines;
 
 macro_rules! impl_collect_chunks_async {
-    ($receiver:expr, $collect:ident, $sink:ident, $handler:ident) => {{
+    ($stream_name:expr, $receiver:expr, $collect:ident, $sink:ident, $handler:ident) => {{
         let (term_sig_tx, mut term_sig_rx) = tokio::sync::oneshot::channel::<()>();
         Collector {
+            stream_name: $stream_name,
             task: Some(tokio::spawn(async move {
                 $handler!('outer, $receiver, term_sig_rx, |maybe_chunk| {
                     match maybe_chunk {
@@ -181,9 +187,10 @@ macro_rules! impl_collect_chunks_async {
 pub(crate) use impl_collect_chunks_async;
 
 macro_rules! impl_collect_lines_async {
-    ($receiver:expr, $collect:ident, $options:ident, $sink:ident, $handler:ident) => {{
+    ($stream_name:expr, $receiver:expr, $collect:ident, $options:ident, $sink:ident, $handler:ident) => {{
         let (term_sig_tx, mut term_sig_rx) = tokio::sync::oneshot::channel::<()>();
         Collector {
+            stream_name: $stream_name,
             task: Some(tokio::spawn(async move {
                 let mut line_buffer = bytes::BytesMut::new();
                 $handler!('outer, $receiver, term_sig_rx, |maybe_chunk| {

--- a/src/output_stream/mod.rs
+++ b/src/output_stream/mod.rs
@@ -20,13 +20,15 @@ pub mod single_subscriber;
 /// - [broadcast::BroadcastOutputStream]
 /// - [single_subscriber::SingleSubscriberOutputStream]
 pub trait OutputStream {
-
     /// The maximum size of every chunk read by the backing `stream_reader`.
     fn chunk_size(&self) -> NumBytes;
 
-
     /// The number of chunks held by the underlying async channel.
     fn channel_capacity(&self) -> usize;
+
+    /// Type of stream. Can be "stdout" or "stderr". But we do not guarantee this output.
+    /// It should only be used for logging/debugging.
+    fn name(&self) -> &'static str;
 }
 
 /// NOTE: The maximum possible memory consumption is: `chunk_size * channel_capacity`.

--- a/src/process.rs
+++ b/src/process.rs
@@ -1,11 +1,11 @@
 //! Builder API for spawning processes with explicit stream type selection.
 
+use crate::error::SpawnError;
 use crate::output_stream::broadcast::BroadcastOutputStream;
 use crate::output_stream::single_subscriber::SingleSubscriberOutputStream;
 use crate::output_stream::{DEFAULT_CHANNEL_CAPACITY, DEFAULT_CHUNK_SIZE};
 use crate::{NumBytes, ProcessHandle};
 use std::borrow::Cow;
-use std::io;
 
 /// Controls how the process name is automatically generated when not explicitly provided.
 ///
@@ -190,7 +190,7 @@ impl From<AutoName> for ProcessName {
 /// # Examples
 ///
 /// ```no_run
-/// use tokio_process_tools::Process;
+/// use tokio_process_tools::*;
 /// use tokio::process::Command;
 ///
 /// # tokio_test::block_on(async {
@@ -209,7 +209,7 @@ impl From<AutoName> for ProcessName {
 ///     .stdout_capacity(512)
 ///     .stderr_capacity(512)
 ///     .spawn_broadcast()?;
-/// # Ok::<_, std::io::Error>(())
+/// # Ok::<_, SpawnError>(())
 /// # });
 /// ```
 pub struct Process {
@@ -230,13 +230,13 @@ impl Process {
     /// # Examples
     ///
     /// ```no_run
-    /// use tokio_process_tools::Process;
+    /// use tokio_process_tools::*;
     /// use tokio::process::Command;
     ///
     /// # tokio_test::block_on(async {
     /// let process = Process::new(Command::new("ls"))
     ///     .spawn_broadcast()?;
-    /// # Ok::<_, std::io::Error>(())
+    /// # Ok::<_, SpawnError>(())
     /// # });
     /// ```
     pub fn new(cmd: tokio::process::Command) -> Self {
@@ -258,7 +258,7 @@ impl Process {
     /// # Examples
     ///
     /// ```no_run
-    /// use tokio_process_tools::{Process, ProcessName, AutoName, AutoNameSettings};
+    /// use tokio_process_tools::*;
     /// use tokio::process::Command;
     ///
     /// # tokio_test::block_on(async {
@@ -273,7 +273,7 @@ impl Process {
     /// let process = Process::new(cmd)
     ///     .name(ProcessName::Auto(AutoName::Using(AutoNameSettings::program_with_args())))
     ///     .spawn_broadcast()?;
-    /// # Ok::<_, std::io::Error>(())
+    /// # Ok::<_, SpawnError>(())
     /// # });
     /// ```
     pub fn name(mut self, name: impl Into<ProcessName>) -> Self {
@@ -288,7 +288,7 @@ impl Process {
     /// # Examples
     ///
     /// ```no_run
-    /// use tokio_process_tools::Process;
+    /// use tokio_process_tools::*;
     /// use tokio::process::Command;
     ///
     /// # tokio_test::block_on(async {
@@ -302,7 +302,7 @@ impl Process {
     /// let process = Process::new(Command::new("worker"))
     ///     .with_name(format!("worker-{id}"))
     ///     .spawn_single_subscriber()?;
-    /// # Ok::<_, std::io::Error>(())
+    /// # Ok::<_, SpawnError>(())
     /// # });
     /// ```
     pub fn with_name(self, name: impl Into<Cow<'static, str>>) -> Self {
@@ -316,7 +316,7 @@ impl Process {
     /// # Examples
     ///
     /// ```no_run
-    /// use tokio_process_tools::{AutoName, AutoNameSettings, Process};
+    /// use tokio_process_tools::*;
     /// use tokio::process::Command;
     ///
     /// # tokio_test::block_on(async {
@@ -327,7 +327,7 @@ impl Process {
     /// let process = Process::new(cmd)
     ///     .with_auto_name(AutoName::Using(AutoNameSettings::program_with_env_and_args()))
     ///     .spawn_broadcast()?;
-    /// # Ok::<_, std::io::Error>(())
+    /// # Ok::<_, SpawnError>(())
     /// # });
     /// ```
     pub fn with_auto_name(self, mode: AutoName) -> Self {
@@ -342,14 +342,14 @@ impl Process {
     /// # Examples
     ///
     /// ```no_run
-    /// use tokio_process_tools::{NumBytesExt, Process};
+    /// use tokio_process_tools::*;
     /// use tokio::process::Command;
     ///
     /// # tokio_test::block_on(async {
     /// let process = Process::new(Command::new("server"))
     ///     .stdout_chunk_size(32.kilobytes())
     ///     .spawn_broadcast()?;
-    /// # Ok::<_, std::io::Error>(())
+    /// # Ok::<_, SpawnError>(())
     /// # });
     /// ```
     pub fn stdout_chunk_size(mut self, chunk_size: NumBytes) -> Self {
@@ -365,14 +365,14 @@ impl Process {
     /// # Examples
     ///
     /// ```no_run
-    /// use tokio_process_tools::{Process, NumBytesExt};
+    /// use tokio_process_tools::*;
     /// use tokio::process::Command;
     ///
     /// # tokio_test::block_on(async {
     /// let process = Process::new(Command::new("server"))
     ///     .stderr_chunk_size(32.kilobytes())
     ///     .spawn_broadcast()?;
-    /// # Ok::<_, std::io::Error>(())
+    /// # Ok::<_, SpawnError>(())
     /// # });
     /// ```
     pub fn stderr_chunk_size(mut self, chunk_size: NumBytes) -> Self {
@@ -389,14 +389,14 @@ impl Process {
     /// # Examples
     ///
     /// ```no_run
-    /// use tokio_process_tools::{Process, NumBytesExt};
+    /// use tokio_process_tools::*;
     /// use tokio::process::Command;
     ///
     /// # tokio_test::block_on(async {
     /// let process = Process::new(Command::new("server"))
     ///     .chunk_sizes(32.kilobytes())
     ///     .spawn_broadcast()?;
-    /// # Ok::<_, std::io::Error>(())
+    /// # Ok::<_, SpawnError>(())
     /// # });
     /// ```
     pub fn chunk_sizes(mut self, chunk_size: NumBytes) -> Self {
@@ -413,14 +413,14 @@ impl Process {
     /// # Examples
     ///
     /// ```no_run
-    /// use tokio_process_tools::Process;
+    /// use tokio_process_tools::*;
     /// use tokio::process::Command;
     ///
     /// # tokio_test::block_on(async {
     /// let process = Process::new(Command::new("server"))
     ///     .stdout_capacity(512)
     ///     .spawn_broadcast()?;
-    /// # Ok::<_, std::io::Error>(())
+    /// # Ok::<_, SpawnError>(())
     /// # });
     /// ```
     pub fn stdout_capacity(mut self, capacity: usize) -> Self {
@@ -436,14 +436,14 @@ impl Process {
     /// # Examples
     ///
     /// ```no_run
-    /// use tokio_process_tools::Process;
+    /// use tokio_process_tools::*;
     /// use tokio::process::Command;
     ///
     /// # tokio_test::block_on(async {
     /// let process = Process::new(Command::new("server"))
     ///     .stderr_capacity(256)
     ///     .spawn_broadcast()?;
-    /// # Ok::<_, std::io::Error>(())
+    /// # Ok::<_, SpawnError>(())
     /// # });
     /// ```
     pub fn stderr_capacity(mut self, capacity: usize) -> Self {
@@ -459,14 +459,14 @@ impl Process {
     /// # Examples
     ///
     /// ```no_run
-    /// use tokio_process_tools::Process;
+    /// use tokio_process_tools::*;
     /// use tokio::process::Command;
     ///
     /// # tokio_test::block_on(async {
     /// let process = Process::new(Command::new("server"))
     ///     .capacities(256)
     ///     .spawn_broadcast()?;
-    /// # Ok::<_, std::io::Error>(())
+    /// # Ok::<_, SpawnError>(())
     /// # });
     /// ```
     pub fn capacities(mut self, capacity: usize) -> Self {
@@ -495,7 +495,7 @@ impl Process {
     /// # Examples
     ///
     /// ```no_run
-    /// use tokio_process_tools::Process;
+    /// use tokio_process_tools::*;
     /// use tokio::process::Command;
     ///
     /// # tokio_test::block_on(async {
@@ -509,10 +509,10 @@ impl Process {
     /// }, Default::default());
     ///
     /// let _collector = process.stdout().collect_lines_into_vec(Default::default());
-    /// # Ok::<_, std::io::Error>(())
+    /// # Ok::<_, SpawnError>(())
     /// # });
     /// ```
-    pub fn spawn_broadcast(self) -> io::Result<ProcessHandle<BroadcastOutputStream>> {
+    pub fn spawn_broadcast(self) -> Result<ProcessHandle<BroadcastOutputStream>, SpawnError> {
         let name = self.generate_name();
         ProcessHandle::<BroadcastOutputStream>::spawn_with_capacity(
             name,
@@ -533,7 +533,7 @@ impl Process {
     /// # Examples
     ///
     /// ```no_run
-    /// use tokio_process_tools::Process;
+    /// use tokio_process_tools::*;
     /// use tokio::process::Command;
     ///
     /// # tokio_test::block_on(async {
@@ -542,12 +542,12 @@ impl Process {
     ///
     /// // Only one consumer allowed
     /// let collector = process.stdout_mut().collect_lines_into_vec(Default::default());
-    /// # Ok::<_, std::io::Error>(())
+    /// # Ok::<_, SpawnError>(())
     /// # });
     /// ```
     pub fn spawn_single_subscriber(
         self,
-    ) -> io::Result<ProcessHandle<SingleSubscriberOutputStream>> {
+    ) -> Result<ProcessHandle<SingleSubscriberOutputStream>, SpawnError> {
         let name = self.generate_name();
         ProcessHandle::<SingleSubscriberOutputStream>::spawn_with_capacity(
             name,


### PR DESCRIPTION
Centralize error types; Streams are now nameable; Let collectors and inspectors carry over the name of their stream they are operating on