### PR TITLE
Create single subscriber inspectors/collectors through shared ref

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,18 +91,16 @@ When spawning a process, you choose the stream type explicitly by calling either
 ### Single Subscriber (`.spawn_single_subscriber()`)
 
 - ✅ More efficient (lower memory, no cloning)
-- ✅ Single consumer only
 - ✅ Configurable backpressure handling
+- ⚠️ **Only one consumer allowed** - creating a second inspector/collector will panic
 - 💡 **Use when**: You only need one way to consume output (e.g., just collecting OR just monitoring)
-- ☝️Requires `.stdout_mut()` and `.stderr_mut()` for interaction with streams.
 
 ### Broadcast (`.spawn_broadcast()`)
 
 - ✅ Multiple concurrent consumers
 - ✅ Great for logging + collecting + monitoring simultaneously
-- ℹ️ Slightly higher runtime costs
+- ⚠️ Slightly higher runtime costs
 - 💡 **Use when**: You need multiple operations on the same stream (e.g., log to console AND save to file)
-- ☝️Uses `.stdout()` and `.stderr()` for interaction with streams.
 
 ## Output Handling
 
@@ -123,7 +121,7 @@ async fn main() {
         .unwrap();
 
     // Inspect output in real-time
-    let _stdout_monitor = process.stdout_mut().inspect_lines(
+    let _stdout_monitor = process.stdout().inspect_lines(
         |line| {
             println!("stdout: {line}");
             Next::Continue
@@ -159,7 +157,7 @@ async fn main() {
         .unwrap();
 
     // Wait for the server to be ready
-    match process.stdout_mut().wait_for_line_with_timeout(
+    match process.stdout().wait_for_line_with_timeout(
         |line| line.contains("Server listening on"),
         LineParsingOptions::default(),
         Duration::from_secs(30),
@@ -415,7 +413,7 @@ use tokio_process_tools::*;
 #[tokio::main]
 async fn main() {
     let mut cmd = Command::new("some-command");
-    let mut process = Process::new(cmd)
+    let process = Process::new(cmd)
         .spawn_broadcast()
         .unwrap();
     process.stdout().wait_for_line(

--- a/src/process.rs
+++ b/src/process.rs
@@ -537,11 +537,11 @@ impl Process {
     /// use tokio::process::Command;
     ///
     /// # tokio_test::block_on(async {
-    /// let mut process = Process::new(Command::new("ls"))
+    /// let process = Process::new(Command::new("ls"))
     ///     .spawn_single_subscriber()?;
     ///
     /// // Only one consumer allowed
-    /// let collector = process.stdout_mut().collect_lines_into_vec(Default::default());
+    /// let collector = process.stdout().collect_lines_into_vec(Default::default());
     /// # Ok::<_, SpawnError>(())
     /// # });
     /// ```

--- a/src/process_handle.rs
+++ b/src/process_handle.rs
@@ -319,8 +319,8 @@ impl ProcessHandle<SingleSubscriberOutputStream> {
         timeout: Option<Duration>,
         options: LineParsingOptions,
     ) -> Result<Output, WaitError> {
-        let out_collector = self.stdout_mut().collect_lines_into_vec(options);
-        let err_collector = self.stderr_mut().collect_lines_into_vec(options);
+        let out_collector = self.stdout().collect_lines_into_vec(options);
+        let err_collector = self.stderr().collect_lines_into_vec(options);
 
         let status = self.wait_for_completion(timeout).await?;
 
@@ -344,8 +344,8 @@ impl ProcessHandle<SingleSubscriberOutputStream> {
         terminate_timeout: Duration,
         options: LineParsingOptions,
     ) -> Result<Output, WaitError> {
-        let out_collector = self.stdout_mut().collect_lines_into_vec(options);
-        let err_collector = self.stderr_mut().collect_lines_into_vec(options);
+        let out_collector = self.stdout().collect_lines_into_vec(options);
+        let err_collector = self.stderr().collect_lines_into_vec(options);
 
         let status = self
             .wait_for_completion_or_terminate(wait_timeout, interrupt_timeout, terminate_timeout)
@@ -421,23 +421,21 @@ impl<O: OutputStream> ProcessHandle<O> {
     }
 
     /// Returns a reference to the stdout stream.
+    ///
+    /// For `BroadcastOutputStream`, this allows creating multiple concurrent consumers.
+    /// For `SingleSubscriberOutputStream`, only one consumer can be created (subsequent
+    /// attempts will panic with a helpful error message).
     pub fn stdout(&self) -> &O {
         &self.std_out_stream
     }
 
-    /// Returns a mutable reference to the stdout stream.
-    pub fn stdout_mut(&mut self) -> &mut O {
-        &mut self.std_out_stream
-    }
-
     /// Returns a reference to the stderr stream.
+    ///
+    /// For `BroadcastOutputStream`, this allows creating multiple concurrent consumers.
+    /// For `SingleSubscriberOutputStream`, only one consumer can be created (subsequent
+    /// attempts will panic with a helpful error message).
     pub fn stderr(&self) -> &O {
         &self.std_err_stream
-    }
-
-    /// Returns a mutable reference to the stderr stream.
-    pub fn stderr_mut(&mut self) -> &mut O {
-        &mut self.std_err_stream
     }
 
     /// Sets a panic-on-drop mechanism for this `ProcessHandle`.


### PR DESCRIPTION
No matter the stream type, inspectors and collectors can be created through a shared ref provided by `stdout()` and `stderr()`