### PR TITLE
Fixed incorrect constant import (CTRL_C_EVENT & CTRL_BREAK_EVENT) in windows.

### DIFF
--- a/src/signal.rs
+++ b/src/signal.rs
@@ -22,7 +22,7 @@ pub(crate) fn send_interrupt(child: &tokio::process::Child) -> std::io::Result<(
 
     #[cfg(windows)]
     {
-        use windows_sys::Win32::Foundation::CTRL_C_EVENT;
+        use windows_sys::Win32::System::Console::CTRL_C_EVENT;
         use windows_sys::Win32::System::Console::GenerateConsoleCtrlEvent;
 
         let success = unsafe { GenerateConsoleCtrlEvent(CTRL_C_EVENT, pid) };
@@ -61,7 +61,7 @@ pub(crate) fn send_terminate(child: &tokio::process::Child) -> std::io::Result<(
 
     #[cfg(windows)]
     {
-        use windows_sys::Win32::Foundation::CTRL_BREAK_EVENT;
+        use windows_sys::Win32::System::Console::CTRL_BREAK_EVENT;
         use windows_sys::Win32::System::Console::GenerateConsoleCtrlEvent;
 
         let success = unsafe { GenerateConsoleCtrlEvent(CTRL_BREAK_EVENT, pid) };


### PR DESCRIPTION
I was using this library in a cross-platform project of mine but the constant imports for windows_sys were incorrect, the constants `CTRL_C_EVENT` and `CTRL_BREAK_EVENT` were imported approx from `windows_sys::Win32::Foundation` instead of `windows_sys::Win32::System::Console`.